### PR TITLE
Feature/add author

### DIFF
--- a/lib/wordpress_client.rb
+++ b/lib/wordpress_client.rb
@@ -14,6 +14,8 @@ require "wordpress_client/post"
 require "wordpress_client/post_parser"
 require "wordpress_client/media"
 require "wordpress_client/media_parser"
+require "wordpress_client/user"
+require "wordpress_client/author"
 
 module WordpressClient
   # Initialize a new client using the provided connection details.

--- a/lib/wordpress_client/author.rb
+++ b/lib/wordpress_client/author.rb
@@ -1,0 +1,6 @@
+module WordpressClient
+  # Represents a Author from Wordpress.
+  # @see https://developer.wordpress.org/rest-api/reference/users/ API documentation
+  class Author < User
+  end
+end

--- a/lib/wordpress_client/client.rb
+++ b/lib/wordpress_client/client.rb
@@ -108,8 +108,10 @@ module WordpressClient
     # Find {Category Categories} in the Wordpress install.
     #
     # @return {PaginatedCollection[Category]}
-    def categories(per_page: 10, page: 1)
-      connection.get_multiple(Category, "categories", page: page, per_page: per_page)
+    def categories(params={})
+      params[:per_page] ||=  10
+      params[:page] ||= 1 
+      connection.get_multiple(Category, "categories", params)
     end
 
     # Find {Category} with the given ID.

--- a/lib/wordpress_client/client.rb
+++ b/lib/wordpress_client/client.rb
@@ -161,8 +161,10 @@ module WordpressClient
     # Find {Tag Tags} in the Wordpress install.
     #
     # @return {PaginatedCollection[Tag]}
-    def tags(per_page: 10, page: 1)
-      connection.get_multiple(Tag, "tags", page: page, per_page: per_page)
+    def tags(params={})
+      params[:per_page] ||=  10
+      params[:page] ||= 1 
+      connection.get_multiple(Tag, "tags", params)
     end
 
     # Find {Tag} with the given ID.

--- a/lib/wordpress_client/client.rb
+++ b/lib/wordpress_client/client.rb
@@ -15,13 +15,14 @@ module WordpressClient
     # @param per_page [Fixnum] Posts per page. Defaults to 10.
     #
     # @return {PaginatedCollection[Post]} Paginated collection of the found posts.
-    def posts(per_page: 10, page: 1)
+    def posts(params = {})
+      params[:_embed] ||= nil
+      params[:per_page] ||=  10
+      params[:page] ||= 1 
       connection.get_multiple(
         Post,
         "posts",
-        per_page: per_page,
-        page: page,
-        _embed: nil,
+        params
       )
     end
 
@@ -245,6 +246,37 @@ module WordpressClient
     def upload(io, mime_type:, filename:)
       connection.upload(Media, "media", io, mime_type: mime_type, filename: filename)
     end
+
+    # @!group Author
+
+    # Find {Author Authors} matching given parameters.
+    #
+    # @example Finding 5 authors
+    #   authors = client.authors(per_page: 5)
+    #
+    # @param params for que API call
+    #
+    # @return {PaginatedCollection[Post]} Paginated collection of the found posts.
+    def authors(params = {})
+      params[:_embed] ||= nil
+      params[:per_page] ||=  10
+      params[:page] ||= 1 
+      connection.get_multiple(
+        Author,
+        "users",
+        params
+      )
+    end
+
+    # Find the {Author} with the given ID, or raises an error if not found.
+    #
+    # @return {Author}
+    # @raise {NotFoundError}
+    # @raise {subclasses of Error} on other unexpected errors
+    def find_author(id)
+      connection.get(Author, "users/#{id.to_i}", _embed: nil)
+    end
+
 
     # Create a new {Media} by uploading a file from disk.
     #

--- a/lib/wordpress_client/post.rb
+++ b/lib/wordpress_client/post.rb
@@ -10,7 +10,8 @@ module WordpressClient
       :title_html, :excerpt_html, :content_html,
       :updated_at, :date,
       :categories, :tags, :meta, :featured_media,
-      :tag_ids, :category_ids, :featured_media_id
+      :tag_ids, :category_ids, :featured_media_id,
+      :author
     )
 
     # @!attribute [rw] title_html
@@ -57,6 +58,10 @@ module WordpressClient
     #   @see Category
     #   @see Client#update_post
 
+    # @!attribute [rw] author
+    #   @return [Author] the {Author} the post belongs to.
+    #   @see Author
+    
     # @api private
     def self.parse(data)
       PostParser.parse(data)
@@ -79,7 +84,8 @@ module WordpressClient
       category_ids: [],
       tag_ids: [],
       featured_media: nil,
-      meta: {}
+      meta: {},
+      author: nil
     )
       @id = id
       @slug = slug
@@ -97,6 +103,7 @@ module WordpressClient
       @tag_ids = tag_ids
       @featured_media = featured_media
       @meta = meta
+      @author = author
     end
 
     # Returns the featured media, if the featured media is an image.

--- a/lib/wordpress_client/post_parser.rb
+++ b/lib/wordpress_client/post_parser.rb
@@ -20,6 +20,7 @@ module WordpressClient
       assign_categories(post)
       assign_tags(post)
       assign_featured_media(post)
+      assign_author(post)
       post
     end
 
@@ -70,6 +71,11 @@ module WordpressClient
           post.featured_media = Media.parse(media)
         end
       end
+    end
+
+    def assign_author(post)
+      author_data = embedded["author"].first
+      post.author = Author.parse(author_data)
     end
 
     def embedded_terms(type)

--- a/lib/wordpress_client/user.rb
+++ b/lib/wordpress_client/user.rb
@@ -1,0 +1,28 @@
+module WordpressClient
+  # Represents a user from Wordpress.
+  # @see https://developer.wordpress.org/rest-api/reference/users/ API documentation for User
+  class User
+    attr_accessor(
+      :id, :name, :description, :slug, :avatar_urls
+    )
+
+    def self.parse(data)
+      new(
+        id: data.fetch("id"),
+        name: data.fetch("name"),
+        description: data.fetch("description"),
+        slug: data.fetch("slug"),
+        avatar_urls: data.fetch("avatar_urls")
+      )
+    end
+
+    def initialize(id:, name:, description:, slug:, avatar_urls:)
+      @id = id
+      @name = name
+      @description = description
+      @slug = slug 
+      @avatar_urls = avatar_urls
+    end
+
+  end
+end

--- a/lib/wordpress_client/user.rb
+++ b/lib/wordpress_client/user.rb
@@ -24,5 +24,34 @@ module WordpressClient
       @avatar_urls = avatar_urls
     end
 
+    # @api private
+    # Compares another instance. All attributes in this list must be equal for
+    # the instances to be equal:
+    #
+    # * +id+
+    # * +name+
+    # * +description+
+    # * +slug+
+    # * +avatar_urls+
+    #
+    # One must also not be a subclass of the other; they must be the exact same class.
+    def ==(other)
+      if other.is_a? User
+        other.class == self.class &&
+          other.id == id &&
+          other.name == name &&
+          other.description == description &&
+          other.slug == slug &&
+          other.avatar_urls == avatar_urls
+      else
+        super
+      end
+    end
+
+    # Shows a nice representation of the term type.
+    def inspect
+      "#<#{self.class} ##{id} #{name} (#{slug})>"
+    end
+
   end
 end

--- a/spec/author_spec.rb
+++ b/spec/author_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+module WordpressClient
+  describe Author do
+    let(:fixture) { json_fixture("author.json") }
+
+    it "can be parsed from JSON data" do
+      author = Author.parse(fixture)
+
+      expect(author.id).to eq 23
+      expect(author.name).to eq "Test User"
+      expect(author.description).to eq "I am a happy person."
+      expect(author.slug).to eq "test"
+
+    end
+  end
+end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -184,6 +184,37 @@ module WordpressClient
       end
     end
 
+    describe "finding authors" do
+      it "has working pagination" do
+        expect(connection).to receive(:get_multiple).with(
+          Author, "users", hash_including(page: 2, per_page: 13)
+        ).and_return []
+
+        expect(client.authors(per_page: 13, page: 2)).to eq []
+      end
+
+      it "embeds linked resources" do
+        expect(connection).to receive(:get_multiple).with(
+          Author, "users", hash_including(_embed: nil)
+        ).and_return []
+
+        expect(client.authors).to eq []
+      end
+    end
+
+    describe "fetching a single author" do
+      it "embeds linked resources" do
+        author = instance_double(Author)
+
+        expect(connection).to receive(:get).with(
+          Author, "users/5", _embed: nil
+        ).and_return author
+
+        expect(client.find_author(5)).to eq author
+      end
+
+    end
+
     describe "media" do
       it "can be uploaded from IO objects" do
         media = instance_double(Media)

--- a/spec/fixtures/author.json
+++ b/spec/fixtures/author.json
@@ -1,0 +1,28 @@
+{
+  "id":23,
+  "name":"Test User",
+  "url":"http://2.gravatar.com/wp-json/wp/v2/users/23",
+  "description":"I am a happy person.",
+  "slug":"test",
+  "avatar_urls":{
+    "24": "http://2.gravatar.com/avatar/55502f40dc8b7c769880b10874abc9d0?s=24&d=mm&r=g",
+    "48": "http://2.gravatar.com/avatar/55502f40dc8b7c769880b10874abc9d0?s=48&d=mm&r=g",
+    "96": "http://2.gravatar.com/avatar/55502f40dc8b7c769880b10874abc9d0?s=96&d=mm&r=g"
+  },
+  "meta":[
+
+  ],
+  "_links":{
+     "self":[
+        {
+           "href":"http://2.gravatar.com/wp-json/wp/v2/users/23"
+        }
+     ],
+     "collection":[
+        {
+           "href":"http://2.gravatar.com/wp-json/wp/v2/users"
+        }
+     ]
+  }
+}
+

--- a/spec/post_spec.rb
+++ b/spec/post_spec.rb
@@ -54,12 +54,18 @@ module WordpressClient
 
     it "parses author" do
       post = Post.parse(fixture)
-
-      expect(post.author).to eq [
-        Author.new(
-          id: 1, name: "test", slug: "test",
-        )
-      ]
+      urls = {
+        "24" => "http://2.gravatar.com/avatar/55502f40dc8b7c769880b10874abc9d0?s=24&d=mm&r=g",
+        "48" => "http://2.gravatar.com/avatar/55502f40dc8b7c769880b10874abc9d0?s=48&d=mm&r=g",
+        "96" => "http://2.gravatar.com/avatar/55502f40dc8b7c769880b10874abc9d0?s=96&d=mm&r=g"
+      }
+      pp post.author
+      new_author = Author.new(
+        id: 1, name: "test", description:'', slug: "test", avatar_urls: urls,
+      )
+      pp new_author
+      expect(post.author).to eq new_author
+      
 
     end
 

--- a/spec/post_spec.rb
+++ b/spec/post_spec.rb
@@ -52,6 +52,17 @@ module WordpressClient
       expect(post.tag_ids).to eq [2]
     end
 
+    it "parses author" do
+      post = Post.parse(fixture)
+
+      expect(post.author).to eq [
+        Author.new(
+          id: 1, name: "test", slug: "test",
+        )
+      ]
+
+    end
+
     it "can have a Media as featured image" do
       media = instance_double(Media, id: 12)
       post = Post.new(featured_media: media)


### PR DESCRIPTION
## Context
The purpose of the PR is to adapt and expand the current gem in order to work correctly and add needed features. 

Current:
- When you fetch a post it doesn't show anything about the author of the post. 
- Getting posts can only receive: **page** and  **per_page** params

Desired:
- When you fetch a post it also gives you basic information about the posts
- Getting posts can receive more params specified in [Documentation](https://developer.wordpress.org/rest-api/reference/posts/#arguments) 
- Getting authors can receive params specified in [Documentation](https://developer.wordpress.org/rest-api/reference/users/#arguments)

## Tasks
- [x] Add a new Author class
- [x] Modify post parsing to allow get data from the author 
- [x] Modify post getting methods to allow multiple parameters
- [x] Add author getting methods and allow multiple parameters
- [x] Create specs for testing author
- [x] Add specs for testing posts
- [ ] Modify .gemspec 
