### PR TITLE
[WIP] Add search method to client.

### DIFF
--- a/lib/wordpress_client/client.rb
+++ b/lib/wordpress_client/client.rb
@@ -102,6 +102,27 @@ module WordpressClient
       connection.delete("posts/#{id.to_i}", {"force" => force})
     end
 
+    # Search {Post Posts} matching given parameters.
+    #
+    # @example Finding 5 posts about debt
+    #   posts = client.search('debt', per_page: 5)
+    #
+    # @param search [String] Keyword for the search
+    # @param page [Fixnum] Current page for pagination. Defaults to 1.
+    # @param per_page [Fixnum] Posts per page. Defaults to 10.
+    #
+    # @return {PaginatedCollection[Post]} Paginated collection of the found posts.
+    def search(search, params = {})
+      params[:_embed] ||= nil
+      params[:per_page] ||=  10
+      params[:page] ||= 1 
+      connection.get_multiple(
+        Post,
+        "search?search=#{search}",
+        params
+      )
+    end
+
     # @!group Categories
 
     # Find {Category Categories} in the Wordpress install.

--- a/lib/wordpress_client/client.rb
+++ b/lib/wordpress_client/client.rb
@@ -116,9 +116,10 @@ module WordpressClient
       params[:_embed] ||= nil
       params[:per_page] ||=  10
       params[:page] ||= 1 
+      params[:search] = search
       connection.get_multiple(
         Post,
-        "search?search=#{search}",
+        "search",
         params
       )
     end


### PR DESCRIPTION
## Context
The WP API has an endpoint to search posts. more documentation [here](https://developer.wordpress.org/rest-api/reference/search-results/)

## Tasks
- [x] Add search method
- [ ] Specs